### PR TITLE
Allow whitespace and single quotes (') in values after @contains

### DIFF
--- a/secrules.tx
+++ b/secrules.tx
@@ -123,7 +123,7 @@ StringWithSpaces: /[A-Za-z0-9\-\/\ \._]+/;
 PathOrMacro: PathNameValue | MacroVar;
     
 // Filesystem Paths (could be merged with URI, tought)    
-PathNameValue: /[a-z0-9\-_\.\/ ]+/;
+PathNameValue: /[a-z0-9\-_\.\/ ']+/;
 
 // Macros, e.g: %{tx.critical_anomaly_score}
 Macro:  INT | OperationMacro | ExtendedMacro | MacroVar;

--- a/secrules.tx
+++ b/secrules.tx
@@ -123,7 +123,7 @@ StringWithSpaces: /[A-Za-z0-9\-\/\ \._]+/;
 PathOrMacro: PathNameValue | MacroVar;
     
 // Filesystem Paths (could be merged with URI, tought)    
-PathNameValue: /[a-z0-9\-_\.\/]+/;
+PathNameValue: /[a-z0-9\-_\.\/ ]+/;
 
 // Macros, e.g: %{tx.critical_anomaly_score}
 Macro:  INT | OperationMacro | ExtendedMacro | MacroVar;


### PR DESCRIPTION
Fix for failing test in PL https://github.com/coreruleset/coreruleset/pull/1962: Allow whitespace and single quotes (') in values after @contains.