### PR TITLE
Adding RESPONSE_HEADERS into CollectionName

### DIFF
--- a/secrules.tx
+++ b/secrules.tx
@@ -51,7 +51,7 @@ CollectionArgument: AnythingBetweenSingleQuotes | '/' SlashedRegExp '/' | Variab
     
 /* Collections */
 CollectionName:
-    ('ARGS_GET' | 'ARGS_POST' | 'ARGS' | 'ENV' | 'GEO' | 'GLOBAL' | 'IP' | 'MATCHED_VARS_NAMES' | 'MATCHED_VARS' | 'PERF_RULES' | 'REQUEST_COOKIES_NAMES' | 'REQUEST_COOKIES' | 'REQUEST_HEADERS_NAMES' | 'REQUEST_HEADERS' | 'RESPONSE_HEADERS_NAMES' | 'RULE' | 'SESSION' | 'TX')
+    ('ARGS_GET' | 'ARGS_POST' | 'ARGS' | 'ENV' | 'GEO' | 'GLOBAL' | 'IP' | 'MATCHED_VARS_NAMES' | 'MATCHED_VARS' | 'PERF_RULES' | 'REQUEST_COOKIES_NAMES' | 'REQUEST_COOKIES' | 'REQUEST_HEADERS_NAMES' | 'REQUEST_HEADERS' | 'RESPONSE_HEADERS_NAMES' | 'RESPONSE_HEADERS' | 'RULE' | 'SESSION' | 'TX')
 ;
 
 SpecialCollection: 'XML' ':' XPathExpression;


### PR DESCRIPTION
Fixes failing syntax test for https://github.com/coreruleset/coreruleset/pull/1968.