### PR TITLE
fix(deps): run ci with supported python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,18 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        crsversion: [3.3.0, 3.2.0]
-        poetry-version: [1.1.13]
+        crsversion: ['3.3.0', '3.2.0']
+        poetry-version: ['1.1.13']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - name: "Checkout repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
-
+          python-version: ${{ matrix.python-version }}
       - name: Install poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Incomplete parser model and sample application for parsing [Core Rule Set](https
 
     System-wide:
     ```shell
-    sudo pip install -r requirements.txt
+    sudo pip install secrules-parsing
     ```
     User:
     ```shell
-    pip install --user -r requirements.txt
+    pip install --user secrules-parsing
     ```
+
 2. Execute `secrules-parser` specifying the location of the files you want to scan using the -f/--files argument. This takes wildcards or individual files.
    `$ secrules-parser -c -f /owasp-crs/rules/*.conf`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "secrules-parsing"
-version = "0.2.2"
+version = "0.2.3"
 description = "ModSecurity DSL Parser package using textX"
 authors = [
     "Felipe Zipitria <felipe.zipitria@owasp.org>"

--- a/src/secrules_parsing/__init__.py
+++ b/src/secrules_parsing/__init__.py
@@ -1,4 +1,4 @@
-from importlib import metadata
+from importlib_metadata import version
 
 
-__version__ = metadata.version(__package__)
+__version__ = version(__package__)


### PR DESCRIPTION
Signed-off-by: Felipe Zipitria <felipe.zipitria@owasp.org>

- update gh action versions
- run matrix python
- update install method
- use metada dep