### PR TITLE
Allow a-z and . chars on skipAfter

### DIFF
--- a/src/secrules_parsing/model/secrules.tx
+++ b/src/secrules_parsing/model/secrules.tx
@@ -160,7 +160,7 @@ Comment[ws='\t ']:
     /\\\n|^\#.*$/;
 
 /* Tags for jumping from rules e.g: END-DRUPAL-RULE-EXCLUSIONS */    
-SkipTag: /[A-Z0-9-_]+/;
+SkipTag: /[A-Za-z0-9._-]+/;
 
 VariableName: 'tx.' MacroVar '-'? Tag? '-'? MacroVar? | /[A-Za-z0-9_\-\.\/\[\]]+/;
 


### PR DESCRIPTION
this PR allows using a-z and "." characters on skipAfter