### PR TITLE
Enabled ',' (comma) in StringWithMacro expression

### DIFF
--- a/src/secrules_parsing/model/secrules.tx
+++ b/src/secrules_parsing/model/secrules.tx
@@ -183,7 +183,7 @@ IPCIDR: /[0-9a-f\.\:]+/;
 // Single Quote delimited STRING
 SQDelimitedSTRING: "'" msg=MessageValue? ':'? macro=MacroVar? "'";
 // This string has macros inside, but their value isn't stored in a variable for now.
-StringWithMacros: "'" ExtendedMacro "'";
+StringWithMacros: "'" ExtendedMacroWithComma "'";
 // String with spaces: when using streq, there are places where a request line is tested
 StringWithSpaces: /[A-Za-z0-9\-\/\ \._]+/;
 
@@ -197,7 +197,10 @@ Macro:  INT | OperationMacro | ExtendedMacro | MacroVar;
 
 // This extended macro are a little bag of holding...
 ExtendedMacro: /[A-Za-z0-9S\-\_\.\:\ \/\%\{\}\|\+=#?]+/;
-    
+
+// macro with comma, quoted by '
+ExtendedMacroWithComma: /[A-Za-z0-9S\-\_\.\:\ \/\%\{\}\|\+=#?,]+/;
+
 OperationMacro: ('+' | '-') var=MacroVar;
 
 MacroVar: '%{'? /[a-zA-Z0-9-\_\.]+/ '}'?;


### PR DESCRIPTION
This is another form of #36.

Enabled `,` (comma) character in some cases (eg. by `logdata`). With this, the below form is allowed:

```
logdata:'blocked foo, param_with_underscore=%{TX:1}, value_with_underscore=%{TX:2}'
```
Perhaps we have to review the allowed arguments type at the actions, I think there are more actions which allow this in the engine(s) than here. And there is an another used solution, eg.
```
   125      'msg:' msg=MessageValue | ...
   ...
   216  MessageValue: "'" /((\\')|[^\'])*/ "'";
```
which - may be - we can use.