### PR TITLE
fix: allow `$` in collection arguments

### DIFF
--- a/src/secrules_parsing/model/secrules.tx
+++ b/src/secrules_parsing/model/secrules.tx
@@ -169,7 +169,7 @@ Comment[ws='\t ']:
 /* Tags for jumping from rules e.g: END-DRUPAL-RULE-EXCLUSIONS */    
 SkipTag: /[A-Za-z0-9._-]+/;
 
-VariableName: 'tx.' MacroVar '-'? Tag? '-'? MacroVar? | /[A-Za-z0-9_\-\.\/\[\]]+/;
+VariableName: 'tx.' MacroVar '-'? Tag? '-'? MacroVar? | /[A-Za-z0-9_\-\.\/\[\]$]+/;
 
 Phase: /[0-5]/ | 'request' | 'response' | 'logging';
 

--- a/src/secrules_parsing/parser.py
+++ b/src/secrules_parsing/parser.py
@@ -106,7 +106,6 @@ def process_from_str(str, verbose=False, debug=False):
         model = modsec_mm.model_from_str(str)
     except TextXSyntaxError as e:
         model = {
-            "file": rule_file,
             "line": e.line,
             "col": e.col,
             "message": e.message,


### PR DESCRIPTION
`$` is a valid character in a collection argument, e.g.,

ctl:ruleRemoveTargetById=942290;ARGS_NAMES:json.flags.$notjunk