### PR TITLE
fix: setvar argument value special chars

### DIFF
--- a/src/secrules_parsing/model/secrules.tx
+++ b/src/secrules_parsing/model/secrules.tx
@@ -194,13 +194,13 @@ PathOrMacro: PathNameValue | MacroVar;
 PathNameValue: /[a-zA-Z0-9\-_\.\/;]+/;
 
 // Macros, e.g: %{tx.critical_anomaly_score}
-Macro:  INT | OperationMacro | ExtendedMacro | MacroVar;
+Macro:  OperationMacro | ExtendedMacro | MacroVar | ExtendedMacroWithComma | INT;
 
 // This extended macro are a little bag of holding...
 ExtendedMacro: /[A-Za-z0-9S\-\_\.\:\ \/\%\{\}\|\+=#?]+/;
 
 // macro with comma, quoted by '
-ExtendedMacroWithComma: /[A-Za-z0-9S\-\_\.\:\ \/\%\{\}\|\+=#?,]+/;
+ExtendedMacroWithComma: /[A-Za-z0-9S\-\_\.\:\ \/\%\{\}\|\+=#?,\<\>]+/;
 
 OperationMacro: ('+' | '-') var=MacroVar;
 


### PR DESCRIPTION
This PR fixes three things:

* enable `,` (comma) in `setvar` argument's value, eg: `setvar:'tx.false-positive-report-plugin_remote_addr=,%{remote_addr},'`
* enable `<` (less than) and `>` (greater than) characters in `setvar` argument's value, eg: `tx.false-positive-report-plugin_smtp_subject=<server_hostname> - <host_header>: False positive report from CRS'`
* enable multiple numbers separated by space, eg. `setvar:'tx.false-positive-report-plugin_filter_ignore_id=949110 959100 980130 980140'`

Fixes:
* added `ExtendedMacroWithComma` to `Macro`
* added `<` and `>` to `ExtendedMacroWithComma`
* move `INT` (built in token) to the end of `Macro`'s list

Also I added two tests which cover the modifications.

## references

https://github.com/coreruleset/false-positive-report-plugin/pull/3