### PR TITLE
fix: beginswith only allowed single words

### DIFF
--- a/src/secrules_parsing/model/secrules.tx
+++ b/src/secrules_parsing/model/secrules.tx
@@ -93,7 +93,7 @@ AnythingBetweenSingleQuotes: /\'.+\'/;
     
 //- pattern match (pm/pmf)    
 Operator:
-    ('beginsWith' beginswith=PathOrMacro | 'contains' contains=PatternMatch | 'containsWord' containsWord=STRING |
+    ('beginsWith' beginswith=MacroOrString | 'contains' contains=PatternMatch | 'containsWord' containsWord=STRING |
     detectsqli ?= 'detectSQLi' | detectxss ?= 'detectXSS' | 'endsWith' endswith=ExtendedMacro |
     'fuzzyHash' fuzzyhash=STRING | 'eq' eq=INT | 'ge' ge=Macro | geolookup ?= 'geoLookup'  |
     'gsbLookup' gsblookup=INT | 'gt' gt=Macro | 'inspectFile' inspectfile=URI | 'ipMatch' ipmatch+=IPCIDR[','] |
@@ -188,8 +188,6 @@ StringWithMacros: "'" ExtendedMacroWithComma "'";
 // String with spaces: when using streq, there are places where a request line is tested
 StringWithSpaces: /[A-Za-z0-9\-\/\ \._]+/;
 
-PathOrMacro: PathNameValue | MacroVar;
-    
 // Filesystem Paths (could be merged with URI, tought)    
 PathNameValue: /[a-zA-Z0-9\-_\.\/;]+/;
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -26,6 +26,20 @@ def test_operator_begins_with() -> None:
             matches += 1
     assert matches == 1
 
+def test_operator_begins_with_space_separated_string() -> None:
+    """Test @beginsWith operator for space separated string"""
+    rule_text = """
+    SecRule REQUEST_URI "@beginsWith COOLWSD HTTP Agent" \
+        "id:1000,phase:1,deny"
+    """
+    parsed_rule = parser.process_from_str(rule_text)
+    matches = 0
+    for rule in parsed_rule.rules:
+        assert rule.__class__.__name__ == "SecRule"
+        if rule.operator.beginswith == "COOLWSD HTTP Agent":
+            matches += 1
+    assert matches == 1
+
 
 def test_operator_begins_with_macro() -> None:
     """Test @beginsWith operator with macro"""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `@beginsWith` parsing to support values containing spaces.
  * Updated parsing behavior to accept string and macro values more consistently.

* **Tests**
  * Added coverage for `@beginsWith` values such as `COOLWSD HTTP Agent`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->