### PR TITLE
fix: Update `PathNameValue` regex to allow spaces

### DIFF
--- a/src/secrules_parsing/model/secrules.tx
+++ b/src/secrules_parsing/model/secrules.tx
@@ -191,7 +191,7 @@ StringWithSpaces: /[A-Za-z0-9\-\/\ \._]+/;
 PathOrMacro: PathNameValue | MacroVar;
     
 // Filesystem Paths (could be merged with URI, tought)    
-PathNameValue: /[a-zA-Z0-9\-_\.\/;]+\s?/;
+PathNameValue: /[a-zA-Z0-9\s\-_\.\/;]+/;
 
 // Macros, e.g: %{tx.critical_anomaly_score}
 Macro:  OperationMacro | ExtendedMacro | MacroVar | ExtendedMacroWithComma | INT;

--- a/src/secrules_parsing/model/secrules.tx
+++ b/src/secrules_parsing/model/secrules.tx
@@ -191,7 +191,7 @@ StringWithSpaces: /[A-Za-z0-9\-\/\ \._]+/;
 PathOrMacro: PathNameValue | MacroVar;
     
 // Filesystem Paths (could be merged with URI, tought)    
-PathNameValue: /[a-zA-Z0-9\-_\.\/;]+/;
+PathNameValue: /[a-zA-Z0-9\-_\.\/;]+\s?/;
 
 // Macros, e.g: %{tx.critical_anomaly_score}
 Macro:  OperationMacro | ExtendedMacro | MacroVar | ExtendedMacroWithComma | INT;


### PR DESCRIPTION
Fix: https://github.com/coreruleset/coreruleset/actions/runs/27249473070/job/80470580219?pr=4657 where using `pmFromFile` with multiple files produces error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of filesystem path values by allowing optional trailing whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->